### PR TITLE
Try to fix fritz device tracker 10m delay in recognizing not_home

### DIFF
--- a/homeassistant/components/device_tracker/fritz.py
+++ b/homeassistant/components/device_tracker/fritz.py
@@ -52,7 +52,7 @@ class FritzBoxScanner(DeviceScanner):
 
         # Establish a connection to the FRITZ!Box.
         try:
-            self.fritz_box = fc.FritzHosts(
+            self.fritz_box = fc.FritzWLAN(
                 address=self.host, user=self.username, password=self.password)
         except (ValueError, TypeError):
             self.fritz_box = None
@@ -77,13 +77,16 @@ class FritzBoxScanner(DeviceScanner):
         for known_host in self.last_results:
             if known_host['status'] == '1' and known_host.get('mac'):
                 active_hosts.append(known_host['mac'])
+        _LOGGER.debug('Active Hosts:')
+        _LOGGER.debug(active_hosts)
         return active_hosts
 
     def get_device_name(self, mac):
+        # ToDo: Doesn't work with FritzWLAN out of the box
         """Return the name of the given device or None if is not known."""
-        ret = self.fritz_box.get_specific_host_entry(mac).get(
-            'NewHostName'
-        )
+        ret = self.fritz_box.get_specific_host_entry(mac)
+        _LOGGER.debug(ret)
+        ret = ret.get('NewHostName')
         if ret == {}:
             return None
         return ret


### PR DESCRIPTION
@deisi you are into the fritz.py device_tracker component of home-assistant, right? Hope it's fine that I'm reaching out at you :blush: 

I noticed the following issue with the fritz device tracker:
When a device goes offline, the component lists it as home for ~10 more minutes. After investigating, it looks like fritzconnection.fritzhosts is simply still reporting the device as active during this time. 

This small change fixes it for me (but needs some more work like getting the device name). Also, there need to be done changes at fritzconnection I think, since FritzWLAN is not imported and there is a syntax error with python3.6 (I will report / ask this at the fritzconnection Bitbucket repo later).

Can you elaborate on why we use fritzhosts and not fritzwlan? Any other thoughts on this issue?

NB: This is just a dummy-PR into the dev branch of my fork since I wanted to communicate this issue before bringing it upstream into home-assistant.